### PR TITLE
Fix intermediate rotations in SO3 constructor

### DIFF
--- a/so3.h
+++ b/so3.h
@@ -90,10 +90,10 @@ public:
 		Matrix<3> R1;
 		R1.T()[0] = unit(a);
 		R1.T()[1] = n;
-		R1.T()[2] = n ^ R1.T()[0];
+		R1.T()[2] = R1.T()[0] ^ n;
 		my_matrix.T()[0] = unit(b);
 		my_matrix.T()[1] = n;
-		my_matrix.T()[2] = n ^ my_matrix.T()[0];
+		my_matrix.T()[2] = my_matrix.T()[0] ^ n;
 		my_matrix = my_matrix * R1.T();
 	}
 	


### PR DESCRIPTION
- This applies to the SO3 constructor that takes two vectors ‘a’ and ‘b’
  as arguments and computes the rotation matrix that brings vector ‘a’
  into the direction of vector ‘b’.
- Previously the intermediate rotation matrices used to compute the
  final result were not valid elements of SO3, since they had
  negative determinants.
- This fix does not alter the final result of the function, but it does
  ensure that the intermediate results are valid rotation matrices.
