### PR TITLE
Add missing <algorithm> includes

### DIFF
--- a/TooN/QR.h
+++ b/TooN/QR.h
@@ -29,6 +29,7 @@
 #ifndef TOON_INC_QR_H
 #define TOON_INC_QR_H
 #include <TooN/TooN.h>
+#include <algorithm>
 #include <cmath>
 
 namespace TooN

--- a/TooN/QR_Lapack.h
+++ b/TooN/QR_Lapack.h
@@ -29,6 +29,7 @@
 
 #include <TooN/TooN.h>
 #include <TooN/lapack.h>
+#include <algorithm>
 #include <utility>
 
 namespace TooN{

--- a/TooN/SVD.h
+++ b/TooN/SVD.h
@@ -30,6 +30,7 @@
 
 #include <TooN/TooN.h>
 #include <TooN/lapack.h>
+#include <algorithm>
 
 namespace TooN {
 

--- a/TooN/SymEigen.h
+++ b/TooN/SymEigen.h
@@ -28,6 +28,7 @@
 #ifndef __SYMEIGEN_H
 #define __SYMEIGEN_H
 
+#include <algorithm>
 #include <iostream>
 #include <cassert>
 #include <cmath>

--- a/TooN/functions/derivatives.h
+++ b/TooN/functions/derivatives.h
@@ -27,6 +27,7 @@
 #define TOON_INCLUDE_DERIVATIVES_NUMERICAL_H
 
 #include <TooN/TooN.h>
+#include <algorithm>
 #include <vector>
 #include <cmath>
 

--- a/TooN/helpers.h
+++ b/TooN/helpers.h
@@ -32,6 +32,7 @@
 
 #include <TooN/TooN.h>
 #include <TooN/gaussian_elimination.h>
+#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <utility>

--- a/TooN/optimization/brent.h
+++ b/TooN/optimization/brent.h
@@ -27,6 +27,7 @@
 #define TOON_BRENT_H
 #include <TooN/TooN.h>
 #include <TooN/helpers.h>
+#include <algorithm>
 #include <limits>
 #include <cmath>
 #include <cstdlib>


### PR DESCRIPTION
Several TooN files use `std::min` or `std::max`, but do not include `<algorithm>` (https://en.cppreference.com/w/cpp/algorithm/max). This change adds the missing header includes.