### PR TITLE
Use a macro to set the DefaultPrecision

### DIFF
--- a/TooN/TooN.h
+++ b/TooN/TooN.h
@@ -309,7 +309,11 @@ namespace TooN {
 	}
 	
 	///All TooN classes default to using this precision for computations and storage.
-typedef double DefaultPrecision;
+#if defined TOON_DEFAULT_PRECISION_TYPE
+        typedef TOON_DEFAULT_PRECISION_TYPE DefaultPrecision;
+#else
+        typedef double DefaultPrecision;
+#endif
 
 #if defined  TOON_FORTRAN_INTEGER && defined TOON_CLAPACK
 	#error Error: both TOON_FORTRAN_INTEGER and TOON_CLAPACK defined


### PR DESCRIPTION
`DefaultPrecision` is fixed to double, making it hard for this library to work with other frameworks using different precision. This PR allows to define the precision with a macro, and use `double` as default fallback for not breaking existing code.